### PR TITLE
Update Ubuntu from 18.04 to 22.04

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,14 +16,17 @@ RUN echo "root:changeme" | chpasswd
 
 # Installing webssh2
 
-RUN apt-get install -y curl
-RUN curl -sL https://deb.nodesource.com/setup_13.x | sudo -E bash -
-RUN apt-get install -y nodejs
-RUN apt-get install -y git
+RUN apt-get install -y curl git xz-utils
+# Manually install nodejs as ubuntu:22.04 is not yet supported for nodejs
+RUN curl https://nodejs.org/dist/v16.13.0/node-v16.13.0-linux-x64.tar.xz -o node.tar.xz
+RUN mkdir -p /usr/local/lib/nodejs
+RUN tar -xf node.tar.xz -C /usr/local/lib/nodejs 
+ENV PATH "$PATH:/usr/local/lib/nodejs/node-v16.13.0-linux-x64/bin"
+RUN npm version
 RUN cd /root && git clone https://github.com/CChemin/webssh2.git
 ADD webssh2-config.json /root/webssh2/app/config.json
 RUN cd ~/webssh2 && git checkout default-host-at-root-path && cd ~/webssh2/app && npm install --production
 
 VOLUME ["/root/"]
-CMD /usr/sbin/sshd ; /usr/bin/node /root/webssh2/app/index.js
+CMD /usr/sbin/sshd ; node /root/webssh2/app/index.js
 EXPOSE 22 2222

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:18.04
+FROM ubuntu:22.04
 
 RUN yes | unminimize
 


### PR DESCRIPTION
Let’s upgrade cloudshell to the next LTS version.